### PR TITLE
test(websocket): fix data race from t.Logf in server handler defers

### DIFF
--- a/client/websocket/client_test.go
+++ b/client/websocket/client_test.go
@@ -71,10 +71,10 @@ func TestNewClient_Success(t *testing.T) {
 			t.Fatalf("Failed to upgrade connection: %v", err)
 		}
 		defer func() {
-			err := c.Close(websocket.StatusNormalClosure, "test completed")
-			if err != nil {
-				t.Logf("Failed to close connection: %v", err)
-			}
+			// Close errors are informational only; using t.Logf here would race
+			// with the test runtime because this defer can fire after the test has
+			// returned (see Go race detector reports).
+			_ = c.Close(websocket.StatusNormalClosure, "test completed")
 		}()
 		// Test connection success only
 	}))
@@ -106,10 +106,10 @@ func TestNewClient_Timeout(t *testing.T) {
 			return
 		}
 		defer func() {
-			err := c.Close(websocket.StatusNormalClosure, "test completed")
-			if err != nil {
-				t.Logf("Failed to close connection: %v", err)
-			}
+			// Close errors are informational only; using t.Logf here would race
+			// with the test runtime because this defer can fire after the test has
+			// returned (see Go race detector reports).
+			_ = c.Close(websocket.StatusNormalClosure, "test completed")
 		}()
 	}))
 	defer server.Close()
@@ -333,10 +333,10 @@ func TestAuth_InvalidCredentials(t *testing.T) {
 			t.Fatalf("Failed to upgrade connection: %v", err)
 		}
 		defer func() {
-			err := c.Close(websocket.StatusNormalClosure, "test completed")
-			if err != nil {
-				t.Logf("Failed to close connection: %v", err)
-			}
+			// Close errors are informational only; using t.Logf here would race
+			// with the test runtime because this defer can fire after the test has
+			// returned (see Go race detector reports).
+			_ = c.Close(websocket.StatusNormalClosure, "test completed")
 		}()
 		// After connection, do nothing
 	}))
@@ -392,10 +392,10 @@ func TestContextCancellation(t *testing.T) {
 			return
 		}
 		defer func() {
-			err := c.Close(websocket.StatusNormalClosure, "test completed")
-			if err != nil {
-				t.Logf("Failed to close connection: %v", err)
-			}
+			// Close errors are informational only; using t.Logf here would race
+			// with the test runtime because this defer can fire after the test has
+			// returned (see Go race detector reports).
+			_ = c.Close(websocket.StatusNormalClosure, "test completed")
 		}()
 		// After connection is established, client waits for message from client forever
 		for {


### PR DESCRIPTION
## Why

CI on `main` (and therefore every Dependabot PR) is failing the `Test/test` job under `-race` with:

```
WARNING: DATA RACE
...
testing.(*common).Logf()
github.com/bmf-san/go-bitflyer-api-client/client/websocket.TestNewClient_Success.func1.1()
    client/websocket/client_test.go:76
```

The deferred `c.Close(...)` inside the `httptest.NewServer` HandlerFunc runs in the server's goroutine, which can outlive the test goroutine. Calling `t.Logf` from there races with the testing runtime's bookkeeping (Go 1.20+ enforces this). Result: race detector trips → `FAIL` → no Dependabot PR can merge.

## What

Replace the four occurrences of

```go
err := c.Close(websocket.StatusNormalClosure, "test completed")
if err != nil {
    t.Logf("Failed to close connection: %v", err)
}
```

with

```go
_ = c.Close(websocket.StatusNormalClosure, "test completed")
```

The close error is purely informational in these mock-server defers, so dropping it is the smallest safe fix. Comment added explaining why we don't call `t.Logf` here.

## Verify

```
$ go test -race ./client/websocket/...
ok  github.com/bmf-san/go-bitflyer-api-client/client/websocket  1.78s
```

## Impact

Unblocks Dependabot PR #27 (`oapi-codegen/runtime` 1.4.0).